### PR TITLE
Add comprehensive Mutagen setup and usage guide

### DIFF
--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -7,3 +7,105 @@
 <https://mutagen.io/>
 
 <https://github.com/mutagen-io/mutagen>
+
+---
+
+## 설치(Installation)
+
+### macOS
+
+```bash
+brew install mutagen-io/mutagen/mutagen
+```
+
+### Linux/Windows
+
+<https://github.com/mutagen-io/mutagen/releases>에서 바이너리 다운로드
+
+---
+
+## 기본 사용법(Basic Usage)
+
+### 파일 동기화(File Sync)
+
+로컬과 원격 서버 간 파일 동기화:
+
+```bash
+# 동기화 세션 생성
+mutagen sync create <로컬경로> <사용자>@<호스트>:<원격경로>
+
+# 예시
+mutagen sync create ~/project user@example.com:~/project
+```
+
+### 포트 포워딩(Port Forwarding)
+
+원격 서버의 포트를 로컬에서 접근:
+
+```bash
+# 포워딩 세션 생성
+mutagen forward create <로컬포트> <사용자>@<호스트>:<원격포트>
+
+# 예시 (원격 3000번 포트를 로컬 3000번으로)
+mutagen forward create tcp:localhost:3000 user@example.com:tcp:localhost:3000
+```
+
+---
+
+## 주요 명령어(Key Commands)
+
+```bash
+# 모든 세션 목록 확인
+mutagen sync list
+mutagen forward list
+
+# 세션 상태 모니터링
+mutagen sync monitor
+
+# 세션 일시정지/재개
+mutagen sync pause <세션명>
+mutagen sync resume <세션명>
+
+# 세션 종료
+mutagen sync terminate <세션명>
+mutagen forward terminate <세션명>
+
+# 모든 세션 종료
+mutagen sync terminate --all
+mutagen forward terminate --all
+```
+
+---
+
+## 설정 파일(Configuration)
+
+프로젝트 루트에 `mutagen.yml` 파일로 설정 관리:
+
+```yaml
+sync:
+  defaults:
+    ignore:
+      vcs: true
+      paths:
+        - "node_modules/"
+        - ".git/"
+        - "*.log"
+  project:
+    alpha: "."
+    beta: "user@example.com:~/project"
+    mode: "two-way-resolved"
+```
+
+설정 파일을 사용한 세션 생성:
+
+```bash
+mutagen project start
+```
+
+---
+
+## 유용한 팁(Tips)
+
+- **성능**: `.mutagen-ignore` 파일로 불필요한 파일 제외
+- **충돌 해결**: `two-way-resolved` 모드는 최신 파일 우선
+- **SSH 설정**: `~/.ssh/config`에 호스트 별칭 설정하면 편리

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -11,8 +11,8 @@
 ## 세팅
 
 용어 정리:
-- **로컬 Mac**: 내 개발 머신 (코드 작성)
-- **원격 Mac**: 빌드/실행 머신 (성능 좋은 Mac)
+- **Alpha**: 로컬 Mac (내 개발 머신, 코드 작성)
+- **Beta**: 원격 Mac (빌드/실행 머신, 성능 좋은 Mac)
 
 1번만 원격 컴퓨터에서 세팅하고 나머지는 로컬 컴퓨터에서 처리합니다.
 
@@ -22,15 +22,11 @@
 
 ### 2. Mutagen 설치
 
-Homebrew로 설치:
-
 ```bash
 brew install mutagen-io/mutagen/mutagen
 ```
 
 ### 3. SSH 공개키 복사
-
-원격 Mac에 공개키 복사:
 
 ```bash
 ssh-copy-id your-username@192.168.1.100
@@ -38,15 +34,11 @@ ssh-copy-id your-username@192.168.1.100
 
 ### 4. 프로젝트 폴더로 이동
 
-작업할 프로젝트 폴더로 이동:
-
 ```bash
 cd ~/my-project
 ```
 
 ### 5. 프로젝트 동기화 시작
-
-동기화 시작:
 
 ```bash
 mutagen sync create . your-username@192.168.1.100:~/my-project
@@ -56,19 +48,18 @@ mutagen sync create . your-username@192.168.1.100:~/my-project
 
 ### 6. 동기화 상태 확인
 
-동기화 상태 확인:
-
 ```bash
 # 동기화 상태 확인
 mutagen sync list
+
+# 상세 정보 확인
+mutagen sync list --long
 
 # 실시간 모니터링
 mutagen sync monitor
 ```
 
 ## 세션 관리
-
-세션 관리:
 
 ```bash
 # 세션 일시정지 (배터리 절약)

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -26,11 +26,7 @@ brew install mutagen-io/mutagen/mutagen
 
 **[원격]** 원격 로그인 활성화:
 
-```bash
-# 시스템 설정 > 일반 > 공유 > 원격 로그인 활성화
-# 또는 터미널에서:
-sudo systemsetup -setremotelogin on
-```
+시스템 설정 > 일반 > 공유 > 원격 로그인 활성화
 
 **[로컬]** SSH 키 생성 (없다면):
 

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -6,13 +6,11 @@
 
 <https://github.com/mutagen-io/mutagen>
 
-## 설치
+## 세팅
 
 ```bash
 brew install mutagen-io/mutagen/mutagen
 ```
-
-## 빠른 시작
 
 ### 1. SSH 연결 설정
 

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -18,11 +18,11 @@
 
 ### 1. 원격 컴퓨터에 원격 로그인 활성화
 
-**[원격]** 시스템 설정 > 일반 > 공유 > 원격 로그인 활성화
+시스템 설정 > 일반 > 공유 > 원격 로그인 활성화
 
 ### 2. Mutagen 설치
 
-**[로컬]** Homebrew로 설치:
+Homebrew로 설치:
 
 ```bash
 brew install mutagen-io/mutagen/mutagen
@@ -30,7 +30,7 @@ brew install mutagen-io/mutagen/mutagen
 
 ### 3. SSH 공개키 복사
 
-**[로컬]** 원격 Mac에 공개키 복사:
+원격 Mac에 공개키 복사:
 
 ```bash
 ssh-copy-id your-username@192.168.1.100
@@ -38,7 +38,7 @@ ssh-copy-id your-username@192.168.1.100
 
 ### 4. 프로젝트 폴더로 이동
 
-**[로컬]** 작업할 프로젝트 폴더로 이동:
+작업할 프로젝트 폴더로 이동:
 
 ```bash
 cd ~/my-project
@@ -46,7 +46,7 @@ cd ~/my-project
 
 ### 5. 동기화 제외 파일 설정
 
-**[로컬]** 프로젝트 루트에 `.mutagen-ignore` 파일 생성:
+프로젝트 루트에 `.mutagen-ignore` 파일 생성:
 
 ```
 node_modules/
@@ -59,7 +59,7 @@ build/
 
 ### 6. 프로젝트 동기화 시작
 
-**[로컬]** 동기화 시작:
+동기화 시작:
 
 ```bash
 mutagen sync create . your-username@192.168.1.100:~/my-project
@@ -69,7 +69,7 @@ mutagen sync create . your-username@192.168.1.100:~/my-project
 
 ### 7. 동기화 상태 확인
 
-**[로컬]** 동기화 상태 확인:
+동기화 상태 확인:
 
 ```bash
 # 동기화 상태 확인
@@ -81,7 +81,7 @@ mutagen sync monitor
 
 ## 세션 관리
 
-**[로컬]** 세션 관리:
+세션 관리:
 
 ```bash
 # 세션 일시정지 (배터리 절약)

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -8,7 +8,7 @@
 
 <https://github.com/mutagen-io/mutagen>
 
-## 설치(Installation)
+## 설치
 
 ### macOS
 
@@ -20,9 +20,9 @@ brew install mutagen-io/mutagen/mutagen
 
 <https://github.com/mutagen-io/mutagen/releases>에서 바이너리 다운로드
 
-## 기본 사용법(Basic Usage)
+## 기본 사용법
 
-### 파일 동기화(File Sync)
+### 파일 동기화
 
 로컬과 원격 서버 간 파일 동기화:
 
@@ -34,7 +34,7 @@ mutagen sync create <로컬경로> <사용자>@<호스트>:<원격경로>
 mutagen sync create ~/project user@example.com:~/project
 ```
 
-### 포트 포워딩(Port Forwarding)
+### 포트 포워딩
 
 원격 서버의 포트를 로컬에서 접근:
 
@@ -46,7 +46,7 @@ mutagen forward create <로컬포트> <사용자>@<호스트>:<원격포트>
 mutagen forward create tcp:localhost:3000 user@example.com:tcp:localhost:3000
 ```
 
-## 주요 명령어(Key Commands)
+## 주요 명령어
 
 ```bash
 # 모든 세션 목록 확인
@@ -69,7 +69,7 @@ mutagen sync terminate --all
 mutagen forward terminate --all
 ```
 
-## 설정 파일(Configuration)
+## 설정 파일
 
 프로젝트 루트에 `mutagen.yml` 파일로 설정 관리:
 
@@ -94,7 +94,7 @@ sync:
 mutagen project start
 ```
 
-## 유용한 팁(Tips)
+## 유용한 팁
 
 - **성능**: `.mutagen-ignore` 파일로 불필요한 파일 제외
 - **충돌 해결**: `two-way-resolved` 모드는 최신 파일 우선

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -1,6 +1,8 @@
 # Mutagen
 
-> 로컬 개발 환경을 그대로 유지하면서 원격 서버에서 작업하기
+> Cloud-based development using your local tools
+
+> Fast file synchronization and network forwarding for remote development
 
 <https://mutagen.io/>
 

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -28,30 +28,6 @@ brew install mutagen-io/mutagen/mutagen
 
 시스템 설정 > 일반 > 공유 > 원격 로그인 활성화
 
-**[로컬]** SSH 키 생성 (없다면):
-
-```bash
-ssh-keygen -t rsa -b 4096
-```
-
-**[로컬]** 원격 Mac에 공개키 복사:
-
-```bash
-# 192.168.1.100을 원격 Mac IP로 변경
-ssh-copy-id your-username@192.168.1.100
-```
-
-**[로컬]** `~/.ssh/config` 파일로 연결 간소화:
-
-```bash
-Host remote-mac
-    HostName 192.168.1.100
-    User your-username
-    IdentityFile ~/.ssh/id_rsa
-```
-
-이제 `ssh remote-mac`으로 간단하게 접속할 수 있습니다.
-
 ### 3. 프로젝트 동기화
 
 **[로컬]** 프로젝트 폴더에서 동기화 시작:

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -44,20 +44,7 @@ ssh-copy-id your-username@192.168.1.100
 cd ~/my-project
 ```
 
-### 5. 동기화 제외 파일 설정
-
-프로젝트 루트에 `.mutagen-ignore` 파일 생성:
-
-```
-node_modules/
-.git/
-*.log
-.DS_Store
-dist/
-build/
-```
-
-### 6. 프로젝트 동기화 시작
+### 5. 프로젝트 동기화 시작
 
 동기화 시작:
 
@@ -67,7 +54,7 @@ mutagen sync create . your-username@192.168.1.100:~/my-project
 
 파일 변경사항이 자동으로 양방향 동기화됩니다. 로컬에서 코드를 수정하면 원격에 즉시 반영되고, 원격에서 빌드 결과물이 생성되면 로컬에도 동기화됩니다.
 
-### 7. 동기화 상태 확인
+### 6. 동기화 상태 확인
 
 동기화 상태 확인:
 

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -8,15 +8,21 @@
 
 ## 세팅
 
+용어 정리:
+- **로컬 Mac**: 내 개발 머신 (코드 작성)
+- **원격 Mac**: 빌드/실행 머신 (성능 좋은 Mac)
+
+### 1. Mutagen 설치
+
+**[로컬]** Homebrew로 설치:
+
 ```bash
 brew install mutagen-io/mutagen/mutagen
 ```
 
-### 1. SSH 연결 설정
+### 2. SSH 연결 설정
 
-원격 Mac에 SSH로 연결할 수 있도록 설정합니다.
-
-**원격 Mac에서** (동기화 대상):
+**[원격]** 원격 로그인 활성화:
 
 ```bash
 # 시스템 설정 > 일반 > 공유 > 원격 로그인 활성화
@@ -24,9 +30,20 @@ brew install mutagen-io/mutagen/mutagen
 sudo systemsetup -setremotelogin on
 ```
 
-**로컬 Mac에서**:
+**[로컬]** SSH 키 생성 (없다면):
 
-`~/.ssh/config` 파일을 만들어 연결을 간단하게 만듭니다:
+```bash
+ssh-keygen -t rsa -b 4096
+```
+
+**[로컬]** 원격 Mac에 공개키 복사:
+
+```bash
+# 192.168.1.100을 원격 Mac IP로 변경
+ssh-copy-id your-username@192.168.1.100
+```
+
+**[로컬]** `~/.ssh/config` 파일로 연결 간소화:
 
 ```bash
 Host remote-mac
@@ -37,19 +54,9 @@ Host remote-mac
 
 이제 `ssh remote-mac`으로 간단하게 접속할 수 있습니다.
 
-SSH 키가 없다면:
+### 3. 프로젝트 동기화
 
-```bash
-# 키 생성
-ssh-keygen -t rsa -b 4096
-
-# 원격 Mac에 공개키 복사
-ssh-copy-id remote-mac
-```
-
-### 2. 프로젝트 동기화 시작
-
-로컬 프로젝트 폴더를 원격 Mac과 동기화합니다:
+**[로컬]** 프로젝트 폴더에서 동기화 시작:
 
 ```bash
 cd ~/my-project
@@ -58,9 +65,9 @@ mutagen sync create . remote-mac:~/my-project
 
 파일 변경사항이 자동으로 양방향 동기화됩니다. 로컬에서 코드를 수정하면 원격에 즉시 반영되고, 원격에서 빌드 결과물이 생성되면 로컬에도 동기화됩니다.
 
-### 3. 원격 서버 포트 접근
+### 4. 포트 포워딩
 
-원격에서 실행 중인 웹 서버(예: localhost:3000)를 로컬 브라우저에서 열 수 있습니다:
+**[로컬]** 원격 서버 포트를 로컬에서 접근:
 
 ```bash
 mutagen forward create tcp:localhost:3000 remote-mac:tcp:localhost:3000
@@ -68,7 +75,9 @@ mutagen forward create tcp:localhost:3000 remote-mac:tcp:localhost:3000
 
 이제 로컬 브라우저에서 `http://localhost:3000`으로 접속하면 원격 서버에 연결됩니다.
 
-### 4. 작업 확인
+### 5. 작업 확인
+
+**[로컬]** 동기화 상태 확인:
 
 ```bash
 # 동기화 상태 확인
@@ -83,7 +92,7 @@ mutagen sync monitor
 
 ## 프로젝트 설정 파일
 
-매번 명령어를 입력하기 번거롭다면, 프로젝트 루트에 `mutagen.yml` 파일을 만듭니다:
+**[로컬]** 매번 명령어를 입력하기 번거롭다면, 프로젝트 루트에 `mutagen.yml` 파일을 만듭니다:
 
 ```yaml
 sync:
@@ -106,19 +115,21 @@ forward:
     destination: "remote-mac:tcp:localhost:3000"
 ```
 
-이제 한 번에 시작:
+**[로컬]** 한 번에 시작:
 
 ```bash
 mutagen project start
 ```
 
-작업 종료:
+**[로컬]** 작업 종료:
 
 ```bash
 mutagen project terminate
 ```
 
 ## 자주 사용하는 명령어
+
+**[로컬]** 세션 관리:
 
 ```bash
 # 세션 일시정지 (배터리 절약)
@@ -136,7 +147,7 @@ mutagen forward terminate --all
 
 ### 동기화에서 제외할 파일
 
-프로젝트 루트에 `.mutagen-ignore` 파일 생성:
+**[로컬]** 프로젝트 루트에 `.mutagen-ignore` 파일 생성:
 
 ```
 node_modules/
@@ -153,7 +164,7 @@ build/
 
 ### 여러 원격 Mac 관리
 
-`~/.ssh/config`에 여러 호스트를 추가:
+**[로컬]** `~/.ssh/config`에 여러 호스트를 추가:
 
 ```
 Host work-mac

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -8,8 +8,6 @@
 
 <https://github.com/mutagen-io/mutagen>
 
----
-
 ## 설치(Installation)
 
 ### macOS
@@ -21,8 +19,6 @@ brew install mutagen-io/mutagen/mutagen
 ### Linux/Windows
 
 <https://github.com/mutagen-io/mutagen/releases>에서 바이너리 다운로드
-
----
 
 ## 기본 사용법(Basic Usage)
 
@@ -50,8 +46,6 @@ mutagen forward create <로컬포트> <사용자>@<호스트>:<원격포트>
 mutagen forward create tcp:localhost:3000 user@example.com:tcp:localhost:3000
 ```
 
----
-
 ## 주요 명령어(Key Commands)
 
 ```bash
@@ -74,8 +68,6 @@ mutagen forward terminate <세션명>
 mutagen sync terminate --all
 mutagen forward terminate --all
 ```
-
----
 
 ## 설정 파일(Configuration)
 
@@ -101,8 +93,6 @@ sync:
 ```bash
 mutagen project start
 ```
-
----
 
 ## 유용한 팁(Tips)
 

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -14,7 +14,13 @@
 - **로컬 Mac**: 내 개발 머신 (코드 작성)
 - **원격 Mac**: 빌드/실행 머신 (성능 좋은 Mac)
 
-### 1. Mutagen 설치
+1번만 원격 컴퓨터에서 세팅하고 나머지는 로컬 컴퓨터에서 처리합니다.
+
+### 1. 원격 컴퓨터에 원격 로그인 활성화
+
+**[원격]** 시스템 설정 > 일반 > 공유 > 원격 로그인 활성화
+
+### 2. Mutagen 설치
 
 **[로컬]** Homebrew로 설치:
 
@@ -22,104 +28,23 @@
 brew install mutagen-io/mutagen/mutagen
 ```
 
-### 2. SSH 연결 설정
+### 3. SSH 공개키 복사
 
-**[원격]** 원격 로그인 활성화:
+**[로컬]** 원격 Mac에 공개키 복사:
 
-시스템 설정 > 일반 > 공유 > 원격 로그인 활성화
+```bash
+ssh-copy-id your-username@192.168.1.100
+```
 
-### 3. 프로젝트 동기화
+### 4. 프로젝트 폴더로 이동
 
-**[로컬]** 프로젝트 폴더에서 동기화 시작:
+**[로컬]** 작업할 프로젝트 폴더로 이동:
 
 ```bash
 cd ~/my-project
-mutagen sync create . remote-mac:~/my-project
 ```
 
-파일 변경사항이 자동으로 양방향 동기화됩니다. 로컬에서 코드를 수정하면 원격에 즉시 반영되고, 원격에서 빌드 결과물이 생성되면 로컬에도 동기화됩니다.
-
-### 4. 포트 포워딩
-
-**[로컬]** 원격 서버 포트를 로컬에서 접근:
-
-```bash
-mutagen forward create tcp:localhost:3000 remote-mac:tcp:localhost:3000
-```
-
-이제 로컬 브라우저에서 `http://localhost:3000`으로 접속하면 원격 서버에 연결됩니다.
-
-### 5. 작업 확인
-
-**[로컬]** 동기화 상태 확인:
-
-```bash
-# 동기화 상태 확인
-mutagen sync list
-
-# 포트 포워딩 상태 확인
-mutagen forward list
-
-# 실시간 모니터링
-mutagen sync monitor
-```
-
-## 프로젝트 설정 파일
-
-**[로컬]** 매번 명령어를 입력하기 번거롭다면, 프로젝트 루트에 `mutagen.yml` 파일을 만듭니다:
-
-```yaml
-sync:
-  defaults:
-    mode: "two-way-resolved"
-    ignore:
-      vcs: true
-      paths:
-        - "node_modules/"
-        - ".git/"
-        - "*.log"
-        - ".DS_Store"
-  my-project:
-    alpha: "."
-    beta: "remote-mac:~/my-project"
-
-forward:
-  web-server:
-    source: "tcp:localhost:3000"
-    destination: "remote-mac:tcp:localhost:3000"
-```
-
-**[로컬]** 한 번에 시작:
-
-```bash
-mutagen project start
-```
-
-**[로컬]** 작업 종료:
-
-```bash
-mutagen project terminate
-```
-
-## 자주 사용하는 명령어
-
-**[로컬]** 세션 관리:
-
-```bash
-# 세션 일시정지 (배터리 절약)
-mutagen sync pause --all
-
-# 세션 재개
-mutagen sync resume --all
-
-# 모든 세션 종료
-mutagen sync terminate --all
-mutagen forward terminate --all
-```
-
-## 팁
-
-### 동기화에서 제외할 파일
+### 5. 동기화 제외 파일 설정
 
 **[로컬]** 프로젝트 루트에 `.mutagen-ignore` 파일 생성:
 
@@ -132,22 +57,39 @@ dist/
 build/
 ```
 
-### 충돌 해결
+### 6. 프로젝트 동기화 시작
 
-`two-way-resolved` 모드는 최신 파일을 자동으로 선택합니다. 같은 파일을 양쪽에서 동시에 수정하면 나중에 저장된 버전이 반영됩니다.
+**[로컬]** 동기화 시작:
 
-### 여러 원격 Mac 관리
-
-**[로컬]** `~/.ssh/config`에 여러 호스트를 추가:
-
-```
-Host work-mac
-    HostName 192.168.1.100
-    User work-user
-
-Host home-mac
-    HostName 192.168.1.200
-    User home-user
+```bash
+mutagen sync create . your-username@192.168.1.100:~/my-project
 ```
 
-각각 다른 동기화 세션으로 관리할 수 있습니다.
+파일 변경사항이 자동으로 양방향 동기화됩니다. 로컬에서 코드를 수정하면 원격에 즉시 반영되고, 원격에서 빌드 결과물이 생성되면 로컬에도 동기화됩니다.
+
+### 7. 동기화 상태 확인
+
+**[로컬]** 동기화 상태 확인:
+
+```bash
+# 동기화 상태 확인
+mutagen sync list
+
+# 실시간 모니터링
+mutagen sync monitor
+```
+
+## 세션 관리
+
+**[로컬]** 세션 관리:
+
+```bash
+# 세션 일시정지 (배터리 절약)
+mutagen sync pause --all
+
+# 세션 재개
+mutagen sync resume --all
+
+# 모든 세션 종료
+mutagen sync terminate --all
+```


### PR DESCRIPTION
Mutagen을 사용한 로컬-원격 Mac 동기화 튜토리얼을 추가합니다.

- Alpha (로컬 Mac), Beta (원격 Mac) 용어 정리
- 단계별 세팅 가이드 (원격 로그인 > 설치 > SSH 키 > 동기화)
- 동기화 상태 확인 방법 (list, list --long, monitor)
- 세션 관리 명령어 (pause, resume, terminate)

https://claude.ai/code/session_01JRcRN9rMCFPgVvKJNMAXvX
