### PR TITLE
Add global ignore configuration guide for Mutagen

### DIFF
--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -71,3 +71,31 @@ mutagen sync resume --all
 # 모든 세션 종료
 mutagen sync terminate --all
 ```
+
+## 전역 Ignore 설정
+
+`~/.mutagen.yml` 파일로 전역 ignore 규칙을 설정할 수 있습니다.
+모든 동기화 세션에 공통으로 적용됩니다.
+
+```yaml
+sync:
+  defaults:
+    ignore:
+      vcs: true
+      paths:
+        - ".claude/settings.local.json"
+        - ".DS_Store"
+        - ".git"
+        - ".gradle"
+        - ".idea/libraries"
+        - ".idea/modules"
+        - ".idea/workspace.xml"
+        - ".venv*"
+        - "_venv*"
+        - "bin"
+        - "build*"
+        - "logs"
+```
+
+- `vcs: true`: VCS 관련 파일을 자동으로 무시합니다.
+- `paths`: 추가로 무시할 경로 패턴을 지정합니다.


### PR DESCRIPTION
## Summary
Added documentation for configuring global ignore rules in Mutagen using the `~/.mutagen.yml` configuration file.

## Changes
- Added a new section "전역 Ignore 설정" (Global Ignore Configuration) to the README
- Provided a complete example of the `~/.mutagen.yml` configuration structure
- Documented the `sync.defaults.ignore` settings with:
  - `vcs: true` option to automatically ignore VCS-related files
  - `paths` array with common patterns to ignore (IDE configs, virtual environments, build artifacts, etc.)
- Added explanatory notes for both configuration options

## Details
This documentation helps users understand how to set up global ignore rules that apply to all Mutagen sync sessions, reducing the need to configure ignore patterns individually for each session. The example includes practical patterns for common development scenarios (Python virtual environments, Gradle builds, IntelliJ IDEA configs, etc.).

https://claude.ai/code/session_01TbnCiDLvxg1rBj9zLHoqYs