### PR TITLE
Add zerobrew to Mac package manager docs

### DIFF
--- a/mac/README.md
+++ b/mac/README.md
@@ -8,6 +8,30 @@
 
 <https://github.com/Homebrew/brew>
 
+## zerobrew
+
+> Homebrew보다 5~20배 빠른 macOS 패키지 매니저
+
+<https://zerobrew.rs/>
+
+<https://github.com/lucasgelfond/zerobrew>
+
+Content-addressable 스토리지, APFS clonefile,
+동시 다운로드 등을 활용해 Homebrew보다
+훨씬 빠른 패키지 설치를 제공한다.
+Brewfile 호환도 지원한다.
+
+```bash
+curl -sSL https://zerobrew.rs/install | bash
+```
+
+```bash
+zb install <package>
+
+# Brewfile로 설치
+zb bundle
+```
+
 ## mas
 
 > 📦 Mac App Store command line interface


### PR DESCRIPTION
Zerobrew is a fast Homebrew alternative for macOS.
It uses content-addressable storage and APFS clonefile
for 5-20x faster package installation.

https://claude.ai/code/session_014mHYtFpTgSQVocmjBE6Qfy