### PR TITLE
Add CSS README with modern-css.com reference

### DIFF
--- a/css/README.md
+++ b/css/README.md
@@ -1,0 +1,13 @@
+# CSS
+
+<https://developer.mozilla.org/ko/docs/Web/CSS>
+
+## modern.css
+
+> Every old CSS hack next to its clean,
+> native replacement — side by side.
+
+오래된 CSS 핵(hack)과 현대적인 CSS 대체 방법을
+나란히 비교해주는 스니펫 모음.
+
+<https://modern-css.com/>


### PR DESCRIPTION
Introduce `css/README.md` with MDN link and `modern-css.com` as a reference for modern CSS replacements of old hacks.

https://claude.ai/code/session_01DRZ9h8Tn2mwqurXK6Y6fxy