### PR TITLE
Add MonoSketch note with practical insights

### DIFF
--- a/prototyping/README.md
+++ b/prototyping/README.md
@@ -1,3 +1,5 @@
 # Prototyping
 
 [더 많은 일을 하면서 더 빨리 하기](https://web.archive.org/web/20230330024213/http://agile.egloos.com/1762301)
+
+- [MonoSketch](./monosketch.md)

--- a/prototyping/monosketch.md
+++ b/prototyping/monosketch.md
@@ -1,0 +1,30 @@
+# MonoSketch
+
+<https://monosketch.io>
+
+MonoSketch는 ASCII 기반으로 스케치와 다이어그램을 만드는 도구다.
+공식 사이트의 핵심 문구는
+"Unleash your ideas with ASCII"다.
+
+## 참고
+
+- Start simple
+- Client - Server communication
+- App System
+- UI mockup
+- Presentations
+- Open source
+
+## 인사이트
+
+ASCII 표현은 그래픽 툴보다 제약이 크다.
+하지만 텍스트 중심 협업(코드 리뷰, 문서 PR, 터미널 환경)에서는
+오히려 공유와 수정 속도를 높여 준다.
+
+초기 아이디어 탐색 단계에서는
+"정교함"보다 "빠른 구조화"가 중요하다.
+MonoSketch 같은 도구는
+구성 요소 관계를 먼저 합의하는 데 유리하다.
+
+또한 결과물이 텍스트라서 버전 관리가 쉽다.
+이미지 기반 산출물보다 diff 확인과 변경 이력 추적이 명확하다.


### PR DESCRIPTION
### Motivation
- MonoSketch에 대한 간단한 소개와 텍스트 기반 프로토타이핑의 실무적 인사이트를 Prototyping 섹션에 추가하려는 목적입니다.

### Description
- `prototyping/monosketch.md` 파일을 새로 추가하여 공식 사이트 링크, 핵심 참고 포인트와 협업·버전관리 관점의 인사이트를 정리했고 `prototyping/README.md`에 새 문서 링크를 추가했습니다.

### Testing
- 런타임 테스트는 필요 없었으며 변경사항은 `git diff --staged --stat`, `git diff --staged`, `git status --short`, 그리고 `git rev-parse --abbrev-ref HEAD && git log -1 --pretty=%B`로 검증했고 모두 정상 확인되어 커밋했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699522ffc8ac8323b1afaeb599faef51)